### PR TITLE
speed ups, QoL additions, groundwork to add more models

### DIFF
--- a/ext/ClapeyronExt.jl
+++ b/ext/ClapeyronExt.jl
@@ -35,4 +35,4 @@ ES._framework_cache(eos::EoSModel) = CL.EoSVectorParam(eos)
 ES._framework_cache(eos::CL.EoSVectorParam) = eos
 ES._framework_cache(eos::MultiFluid) = eos
 
-end
+end #module

--- a/ext/ClapeyronExt.jl
+++ b/ext/ClapeyronExt.jl
@@ -31,4 +31,8 @@ ES.get_m(eos::CL.EoSVectorParam) = ES.get_m(eos.model)
 
 ES.get_components(eos::EoSModel) = eos.components
 
+ES._framework_cache(eos::EoSModel) = CL.EoSVectorParam(eos)
+ES._framework_cache(eos::CL.EoSVectorParam) = eos
+ES._framework_cache(eos::MultiFluid) = eos
+
 end

--- a/ext/ClapeyronExt.jl
+++ b/ext/ClapeyronExt.jl
@@ -3,25 +3,31 @@ module ClapeyronExt
 using EntropyScaling, Clapeyron
 const ES = EntropyScaling
 const CL = Clapeyron
-
+const SA1 = CL.SA[1.0]
 # Bulk properties
-ES.pressure(eos::EoSModel, ϱ, T, z=[1.]) = pressure(eos, 1.0./ϱ, T, z)
+ES.pressure(eos::EoSModel, ϱ, T, z = SA1) = pressure(eos, 1.0./ϱ, T, z)
 
-ES.molar_density(eos::EoSModel, p, T, z=[1.]; phase=:unknown) = molar_density(eos, p, T, z; phase=phase)
+ES.molar_density(eos::EoSModel, p, T, z = SA1; phase=:unknown) = molar_density(eos, p, T, z; phase)
+ES.molar_density(eos::CL.EoSVectorParam, p, T, z = SA1; phase=:unknown) = ES.molar_density(eos.model, p, T, z; phase)
 
-ES.entropy_conf(eos::EoSModel, ϱ, T, z=[1.]) = CL.VT_entropy_res(eos, 1.0./ϱ, T, z)
+ES.entropy_conf(eos::EoSModel, ϱ, T, z = SA1) = CL.VT_entropy_res(eos, 1.0./ϱ, T, z)
+ES.entropy_conf(eos::CL.EoSVectorParam, ϱ, T, z = SA1) = ES.entropy_conf(eos.model, ϱ, T, z)
 
-ES.second_virial_coefficient(eos::EoSModel, T, z=[1.]) = second_virial_coefficient(eos, T, z)
+ES.second_virial_coefficient(eos::EoSModel, T, z = SA1) = second_virial_coefficient(eos, T, z)
+ES.second_virial_coefficient(eos::CL.EoSVectorParam, T, z = SA1) = ES.second_virial_coefficient(eos.model, T, z)
 
 # Critical properties
 ES.crit_pure(eos::EoSModel) = crit_pure(eos)[1:2]
 
 # Utility functions
 ES.split_model(eos::EoSModel) = split_model(eos)
-
+ES.split_model(eos::MultiFluid) = eos.pures
+ES.split_model(eos::CL.EoSVectorParam) = eos.pure
 ES.get_Mw(eos::EoSModel) = eos.params.Mw.values .* 1e-3
+ES.get_Mw(eos::CL.EoSVectorParam) = ES.get_Mw(eos.model)
 
 ES.get_m(eos::EoSModel) = :segment in fieldnames(typeof(eos.params)) ? eos.params.segment.values : ones(length(eos.name))
+ES.get_m(eos::CL.EoSVectorParam) = ES.get_m(eos.model)
 
 ES.get_components(eos::EoSModel) = eos.components
 

--- a/src/EntropyScaling.jl
+++ b/src/EntropyScaling.jl
@@ -9,6 +9,14 @@ get_kBNAR() = (kB=1.380649e-23; NA=6.02214076e23; return (kB,NA,kB*NA))
 
 const DB_PATH = normpath(Base.pkgdir(EntropyScaling),"data")
 
+#equivalent to a' * b, but with general iterators
+function _dot(a,b)
+    res = zero(Base.promote_eltype(a,b))
+    for i in 1:length(a)
+        res += a[i]*b[i]
+    end
+    return res
+end
 # General
 include("general/types.jl")
 include("general/scalings.jl")

--- a/src/general/chapman_enskog.jl
+++ b/src/general/chapman_enskog.jl
@@ -59,10 +59,10 @@ function diffusion_coefficient_CE_plus(eos, T, σ, ε)
     return 3/8/√π / (σ^2*Ω_11(T*kB/ε)) * (T*dBdT+B)^(2/3)
 end
 
-property_CE(prop::Viscosity, T, Mw, σ, ε) = viscosity_CE(T, Mw, σ, ε)
-property_CE_plus(prop::Viscosity, eos, T, σ, ε) = viscosity_CE_plus(eos, T, σ, ε)
-property_CE(prop::ThermalConductivity, T, Mw, σ, ε) = thermal_conductivity_CE(T, Mw, σ, ε)
-property_CE_plus(prop::ThermalConductivity, eos, T, σ, ε) = thermal_conductivity_CE_plus(eos, T, σ, ε)
+property_CE(prop::AbstractViscosity, T, Mw, σ, ε) = viscosity_CE(T, Mw, σ, ε)
+property_CE_plus(prop::AbstractViscosity, eos, T, σ, ε) = viscosity_CE_plus(eos, T, σ, ε)
+property_CE(prop::AbstractThermalConductivity, T, Mw, σ, ε) = thermal_conductivity_CE(T, Mw, σ, ε)
+property_CE_plus(prop::AbstractThermalConductivity, eos, T, σ, ε) = thermal_conductivity_CE_plus(eos, T, σ, ε)
 property_CE(prop::DiffusionCoefficient, T, Mw, σ, ε) = diffusion_coefficient_CE(T, Mw, σ, ε)
 property_CE_plus(prop::DiffusionCoefficient, eos, T, σ, ε) = diffusion_coefficient_CE_plus(eos, T, σ, ε)
 
@@ -148,7 +148,7 @@ Mason and Saxena (1958) for ThermalConductivity.
 (2) Mason, E. A.; Saxena, S. C. Approximate Formula for the Thermal Conductivity of Gas 
 Mixtures. The Physics of Fluids 1958, 1 (5), 361–369. https://doi.org/10.1063/1.1724352.
 """
-function mix_CE(param::BaseParam{P}, Y, x) where {P <: Union{Viscosity, ThermalConductivity}}
+function mix_CE(param::BaseParam{P}, Y, x) where {P <: Union{AbstractViscosity, AbstractThermalConductivity}}
     Y₀_mix = zero(Base.promote_eltype(param.T_range,Y,x))
     zero(Base.promote_eltype(param.T_range,Y,x))
     enum_M = enumerate(param.Mw)
@@ -177,4 +177,4 @@ function mix_CE(param::BaseParam{P}, Y, x) where {P <: DiffusionCoefficient}
     return 1.0 / sum(x[i] / Y[i] for i in eachindex(Y))
 end
 
-calc_M_CE(Mw::Vector{Float64}) = 2.0/sum(inv,Mw)
+calc_M_CE(Mw) = 2.0/sum(inv,Mw)

--- a/src/general/chapman_enskog.jl
+++ b/src/general/chapman_enskog.jl
@@ -73,13 +73,24 @@ Collision integrals from [Kim and Monroe (2014)](https://www.doi.org/10.1016/j.j
 """
 function Ω_22(T_red)
     A = -0.92032979
-    BCi = [ [   2.3508044,      1.6330213       ],
-            [   0.50110649,     -6.9795156e-1   ],
-            [   -4.7193769e-1,  1.6096572e-1,   ],
-            [   1.5806367e-1,   -2.2109440e-2   ],
-            [   -2.6367184e-2,  1.7031434e-3    ],
-            [   1.8120118e-3,   -0.56699986e-4    ]]
-    return A .+ sum([BCi[k][1] ./ T_red.^k .+ BCi[k][2] .* log.(T_red).^k for k in 1:6])
+    BCi = ( (   2.3508044,      1.6330213      ),
+            (   0.50110649,     -6.9795156e-1  ),
+            (   -4.7193769e-1,  1.6096572e-1,  ),
+            (   1.5806367e-1,   -2.2109440e-2  ),
+            (   -2.6367184e-2,  1.7031434e-3   ),
+            (   1.8120118e-3,   -0.56699986e-4 ))
+    Ω22 = zero(1.0*T_red) + A
+    T_red_i = T_red
+    lnT_red = log(T_red)
+    lnT_red_i = lnT_red
+    for k in 1:6
+        BCi1,BCi2 = BCi[k]
+        Ω22 += BCi1/T_red_i + BCi2*lnT_red_i
+        T_red_i *= T_red
+        lnT_red_i *= lnT_red
+    end
+    return Ω22
+    #return A .+ sum([BCi[k][1] ./ T_red.^k .+ BCi[k][2] .* log.(T_red).^k for k in 1:6])
 end
 
 """
@@ -89,13 +100,24 @@ Collision integrals from [Kim and Monroe (2014)](https://www.doi.org/10.1016/j.j
 """
 function Ω_11(T_red)
     A = -1.1036729
-    BCi = [ [   2.6431984,      1.6690746       ],
-            [   0.0060432255,   -6.9145890e-1   ],
-            [   -1.5158773e-1,  1.5502132e-1,   ],
-            [   0.54237938e-1,  -2.0642189e-2   ],
-            [   -0.90468682e-2, 1.5402077e-3    ],
-            [   0.61742007e-3,  -0.49729535e-4  ]]
-    return A .+ sum([BCi[k][1] ./ T_red.^k .+ BCi[k][2] .* log.(T_red).^k for k in 1:6])
+    BCi = ( (   2.6431984,      1.6690746      ),
+            (   0.0060432255,   -6.9145890e-1  ),
+            (   -1.5158773e-1,  1.5502132e-1,  ),
+            (   0.54237938e-1,  -2.0642189e-2  ),
+            (   -0.90468682e-2, 1.5402077e-3   ),
+            (   0.61742007e-3,  -0.49729535e-4 ))
+    Ω11 = zero(1.0*T_red) + A
+    T_red_i = T_red
+    lnT_red = log(T_red)
+    lnT_red_i = lnT_red
+    for k in 1:6
+        BCi1,BCi2 = BCi[k]
+        Ω11 += BCi1/T_red_i + BCi2*lnT_red_i
+        T_red_i *= T_red
+        lnT_red_i *= lnT_red
+    end
+    return Ω11
+    #return A .+ sum([BCi[k][1] ./ T_red.^k .+ BCi[k][2] .* log.(T_red).^k for k in 1:6])
 end
 
 """
@@ -108,7 +130,7 @@ function correspondence_principle(Tc, pc)
     pc_LJ = 0.129
 
     ε = kB*Tc/Tc_LJ
-    σ = (pc_LJ/pc*ε).^(1/3)
+    σ = cbrt(pc_LJ/pc*ε)
     return σ, ε
 end
 
@@ -127,10 +149,15 @@ Mason and Saxena (1958) for ThermalConductivity.
 Mixtures. The Physics of Fluids 1958, 1 (5), 361–369. https://doi.org/10.1063/1.1724352.
 """
 function mix_CE(param::BaseParam{P}, Y, x) where {P <: Union{Viscosity, ThermalConductivity}}
-    Y₀_mix = 0.0
+    Y₀_mix = zero(Base.promote_eltype(param.T_range,Y,x))
+    zero(Base.promote_eltype(param.T_range,Y,x))
     enum_M = enumerate(param.Mw)
     for (i,Mi) in enum_M
-        xΦ = sum([x[j] * (1+√(Y[i]/Y[j])*√√(Mj/Mi))^2 / √(8*(1+Mi/Mj)) for (j,Mj) in enum_M])
+        xΦ = zero(Y₀_mix)
+        for (j,Mj) in enum_M
+            xΦ += x[j] * (1+√(Y[i]/Y[j])*√√(Mj/Mi))^2 / √(8*(1+Mi/Mj))
+        end
+        #xΦ = sum([x[j] * (1+√(Y[i]/Y[j])*√√(Mj/Mi))^2 / √(8*(1+Mi/Mj)) for (j,Mj) in enum_M])
         Y₀_mix += x[i]*Y[i]/xΦ
     end
     return Y₀_mix
@@ -147,7 +174,7 @@ and Experiment for Certain Gas Mixtures. Trans. Faraday Soc. 1961, 57 (0), 2143�
     https://doi.org/10.1039/TF9615702143.
 """
 function mix_CE(param::BaseParam{P}, Y, x) where {P <: DiffusionCoefficient}
-    return 1.0 ./ sum([x[i] / Y[i] for i in eachindex(Y)])
+    return 1.0 / sum(x[i] / Y[i] for i in eachindex(Y))
 end
 
-calc_M_CE(Mw::Vector{Float64}) = 2.0/sum(1.0./Mw)
+calc_M_CE(Mw::Vector{Float64}) = 2.0/sum(inv,Mw)

--- a/src/general/scalings.jl
+++ b/src/general/scalings.jl
@@ -11,19 +11,19 @@ Rosenfeld scaling for transport properties.
 """
 rosenfeld_scaling
 
-function rosenfeld_scaling(param::BaseParam{Viscosity}, η, T, ϱ, z=[1.]; inv=false)
+function rosenfeld_scaling(param::BaseParam{<:AbstractViscosity}, η, T, ϱ, z=[1.]; inv=false)
     k = !inv ? 1 : -1
     Mw = _dot(param.Mw,z)
     return η / ((ϱ*NA)^(2/3) * sqrt(Mw / NA * kB * T))^k
 end
 
-function rosenfeld_scaling(param::BaseParam{ThermalConductivity}, λ, T, ϱ, z=[1.]; inv=false)
+function rosenfeld_scaling(param::BaseParam{<:AbstractThermalConductivity}, λ, T, ϱ, z=[1.]; inv=false)
     k = !inv ? 1 : -1
     Mw = _dot(param.Mw,z)
     return λ / ((ϱ*NA)^(2/3) * kB)^k * sqrt(Mw / (T * kB * NA))^k
 end
 
-function rosenfeld_scaling(param::BaseParam{P}, D, T, ϱ, z=[1.]; inv=false) where P<:DiffusionCoefficient
+function rosenfeld_scaling(param::BaseParam{<:DiffusionCoefficient}, D, T, ϱ, z=[1.]; inv=false)
     k = !inv ? 1 : -1
     Mw = _dot(param.Mw,z)
     return D * sqrt(Mw / (NA * kB * T))^k * (ϱ*NA)^(k/3)

--- a/src/general/scalings.jl
+++ b/src/general/scalings.jl
@@ -13,19 +13,19 @@ rosenfeld_scaling
 
 function rosenfeld_scaling(param::BaseParam{Viscosity}, η, T, ϱ, z=[1.]; inv=false)
     k = !inv ? 1 : -1
-    Mw = sum(param.Mw .* z)
+    Mw = _dot(param.Mw,z)
     return η / ((ϱ*NA)^(2/3) * sqrt(Mw / NA * kB * T))^k
 end
 
 function rosenfeld_scaling(param::BaseParam{ThermalConductivity}, λ, T, ϱ, z=[1.]; inv=false)
     k = !inv ? 1 : -1
-    Mw = sum(param.Mw .* z)
+    Mw = _dot(param.Mw,z)
     return λ / ((ϱ*NA)^(2/3) * kB)^k * sqrt(Mw / (T * kB * NA))^k
 end
 
 function rosenfeld_scaling(param::BaseParam{P}, D, T, ϱ, z=[1.]; inv=false) where P<:DiffusionCoefficient
     k = !inv ? 1 : -1
-    Mw = sum(param.Mw .* z)
+    Mw = _dot(param.Mw,z)
     return D * sqrt(Mw / (NA * kB * T))^k * (ϱ*NA)^(k/3)
 end
 

--- a/src/general/types.jl
+++ b/src/general/types.jl
@@ -21,14 +21,14 @@ struct Reference
 end
 Reference() = Reference("", "NA")
 
-struct BaseParam{P} <: AbstractParam
+struct BaseParam{P,T} <: AbstractParam
     prop::P
     solute_name::Union{Missing,String}
     Mw::Vector{Float64}
     param_ref::Vector{Reference}
     N_data::Int
-    T_range::Tuple{Number,Number}
-    p_range::Tuple{Number,Number}
+    T_range::Tuple{T,T}
+    p_range::Tuple{T,T}
 end
 
 function BaseParam(prop::P, Mw, dat::D; solute=nothing) where 
@@ -37,8 +37,10 @@ function BaseParam(prop::P, Mw, dat::D; solute=nothing) where
     if prop isa InfDiffusionCoefficient
         Mw = [calc_M_CE([Mw[1],get_Mw(solute)[1]])]
     end
-    T_range = (minimum(dat.T), maximum(dat.T))
-    p_range = (minimum(dat.p), maximum(dat.p))
+    TT = Base.promote_eltype(dat.T,dat.p)
+
+    T_range = TT.(extrema(dat.T))
+    p_range = TT.(extrema(dat.p))
     return BaseParam(prop, solute_name, Mw, [Reference()], dat.N_dat, T_range, p_range)
 end
 
@@ -49,6 +51,26 @@ function BaseParam(prop::P, Mw, ref=[Reference()], N_dat=0, T_range=(NaN,NaN),
         Mw = [calc_M_CE(Mw) for _ in 1:length(Mw)]
     end
     return BaseParam(prop, solute_name, Mw, ref, N_dat, T_range, p_range)
+end
+
+function BaseParam{P,TT}(prop::P, Mw, ref=[Reference()], N_dat=0, T_range=(NaN,NaN), 
+    p_range=(NaN,NaN); solute_name=missing) where
+    {TT,P <: AbstractTransportProperty}
+    if prop isa InfDiffusionCoefficient
+        Mw = [calc_M_CE(Mw) for _ in 1:length(Mw)]
+    end
+    return BaseParam(prop, solute_name, Mw, ref, N_dat, TT.(T_range), TT.(p_range))
+end
+
+function Base.convert(::Type{BaseParam{P,T1}},param::BaseParam{P,T2}) where {P,T1,T2}
+    prop = param.prop
+    solute_name = param.solute_name
+    Mw = param.Mw
+    param_ref = param.param_ref
+    N_data = param.N_data
+    T_range = T1.(param.T_range)
+    p_range = T1.(param.p_range)
+    return BaseParam(prop,solute_name,Mw,param_ref,N_data,T_range,p_range)
 end
 
 # function BaseParam(prop::P, )

--- a/src/general/types.jl
+++ b/src/general/types.jl
@@ -108,7 +108,12 @@ symbol_name(::MaxwellStefanDiffusionCoefficient) = "D_MS"
 #used for general comparisons
 transport_compare_type(P1::AbstractTransportProperty,P2::AbstractTransportProperty) = transport_compare_type(typeof(P1),typeof(P2))
 transport_compare_type(P1::Type{T},P2::Type{T}) where T <: AbstractTransportProperty = true
+#get viscosities, thermal conductivities, TODO: do the same structure with diffusion coeffficients?
+transport_compare_type(P1::Type{T1},P2::Type{T2}) where {T1 <: AbstractViscosity,T2 <: AbstractViscosity} = true
+transport_compare_type(P1::Type{T1},P2::Type{T2}) where {T1 <: AbstractThermalConductivity,T2 <: AbstractThermalConductivity} = true
+#fallback
 transport_compare_type(P1::Type{T1},P2::Type{T2}) where {T1 <: AbstractTransportProperty,T2 <: AbstractTransportProperty} = false
+
 
 """
     viscosity(model::EntropyScalingModel, p, T, z=[1.]; phase=:unknown)

--- a/src/general/types.jl
+++ b/src/general/types.jl
@@ -7,10 +7,12 @@ Base.length(model::T) where {T<:AbstractEntropyScalingModel} = length(model.eos)
 
 abstract type AbstractParam end
 abstract type AbstractEntropyScalingParams <: AbstractParam end
-Base.broadcastable(param::T) where {T<:AbstractParam} = Ref(param)
+Base.broadcastable(param::AbstractParam) = Ref(param)
 
 abstract type AbstractTransportProperty end
-Base.broadcastable(prop::T) where {T<:AbstractTransportProperty} = Ref(prop)
+abstract type AbstractViscosity <: AbstractTransportProperty end
+abstract type AbstractThermalConductivity <: AbstractTransportProperty end
+Base.broadcastable(prop::AbstractTransportProperty) = Ref(prop)
 abstract type DiffusionCoefficient <: AbstractTransportProperty end
 
 abstract type AbstractTransportPropertyData end
@@ -31,7 +33,7 @@ struct BaseParam{P,T} <: AbstractParam
     p_range::Tuple{T,T}
 end
 
-function BaseParam(prop::P, Mw, dat::D; solute=nothing) where 
+function BaseParam(prop::P, Mw, dat::D; solute=nothing) where
                    {P <: AbstractTransportProperty, D <: AbstractTransportPropertyData}
     solute_name = isnothing(solute) ? missing : get_components(solute)[1]
     if prop isa InfDiffusionCoefficient
@@ -44,8 +46,8 @@ function BaseParam(prop::P, Mw, dat::D; solute=nothing) where
     return BaseParam(prop, solute_name, Mw, [Reference()], dat.N_dat, T_range, p_range)
 end
 
-function BaseParam(prop::P, Mw, ref=[Reference()], N_dat=0, T_range=(NaN,NaN), 
-                   p_range=(NaN,NaN); solute_name=missing) where 
+function BaseParam(prop::P, Mw, ref=[Reference()], N_dat=0, T_range=(NaN,NaN),
+                   p_range=(NaN,NaN); solute_name=missing) where
                    P <: AbstractTransportProperty
     if prop isa InfDiffusionCoefficient
         Mw = [calc_M_CE(Mw) for _ in 1:length(Mw)]
@@ -53,7 +55,7 @@ function BaseParam(prop::P, Mw, ref=[Reference()], N_dat=0, T_range=(NaN,NaN),
     return BaseParam(prop, solute_name, Mw, ref, N_dat, T_range, p_range)
 end
 
-function BaseParam{P,TT}(prop::P, Mw, ref=[Reference()], N_dat=0, T_range=(NaN,NaN), 
+function BaseParam{P,TT}(prop::P, Mw, ref=[Reference()], N_dat=0, T_range=(NaN,NaN),
     p_range=(NaN,NaN); solute_name=missing) where
     {TT,P <: AbstractTransportProperty}
     if prop isa InfDiffusionCoefficient
@@ -78,15 +80,15 @@ end
 #     return BaseParam(prop, Mw, [Reference("fit")], dat.N_dat, T_range, p_range)
 # end
 
-struct Viscosity <: AbstractTransportProperty end
-name(::Viscosity) = "viscosity"
-symbol(::Viscosity) = :η
-symbol_name(::Viscosity) = "eta"
+struct Viscosity <: AbstractViscosity end
+name(::AbstractViscosity) = "viscosity"
+symbol(::AbstractViscosity) = :η
+symbol_name(::AbstractViscosity) = "eta"
 
-struct ThermalConductivity <: AbstractTransportProperty end
-name(::ThermalConductivity) = "thermal conductivity"
-symbol(::ThermalConductivity) = :λ
-symbol_name(::ThermalConductivity) = "lambda"
+struct ThermalConductivity <: AbstractThermalConductivity end
+name(::AbstractThermalConductivity) = "thermal conductivity"
+symbol(::AbstractThermalConductivity) = :λ
+symbol_name(::AbstractThermalConductivity) = "lambda"
 
 struct SelfDiffusionCoefficient <: DiffusionCoefficient end
 name(::SelfDiffusionCoefficient) = "self-diffusion coefficient"
@@ -102,6 +104,11 @@ struct MaxwellStefanDiffusionCoefficient <: DiffusionCoefficient end
 name(::MaxwellStefanDiffusionCoefficient) = "Maxwell-Stefan diffusion coefficient"
 symbol(::MaxwellStefanDiffusionCoefficient) = :Ð
 symbol_name(::MaxwellStefanDiffusionCoefficient) = "D_MS"
+
+#used for general comparisons
+transport_compare_type(P1::AbstractTransportProperty,P2::AbstractTransportProperty) = transport_compare_type(typeof(P1),typeof(P2))
+transport_compare_type(P1::Type{T},P2::Type{T}) where T <: AbstractTransportProperty = true
+transport_compare_type(P1::Type{T1},P2::Type{T2}) where {T1 <: AbstractTransportProperty,T2 <: AbstractTransportProperty} = false
 
 """
     viscosity(model::EntropyScalingModel, p, T, z=[1.]; phase=:unknown)
@@ -154,7 +161,7 @@ MS_diffusion_coefficient
 
 """
     ϱT_MS_diffusion_coefficient(model::EntropyScalingModel, ϱ, T, z)
-    
+
 Maxwell-Stefan diffusion coefficient `Ð(ϱ,T,x)` (`[Ð] = m² s⁻¹`).
 """
 ϱT_MS_diffusion_coefficient

--- a/src/general/types.jl
+++ b/src/general/types.jl
@@ -23,14 +23,14 @@ struct Reference
 end
 Reference() = Reference("", "NA")
 
-struct BaseParam{P,T} <: AbstractParam
+struct BaseParam{P} <: AbstractParam
     prop::P
     solute_name::Union{Missing,String}
     Mw::Vector{Float64}
     param_ref::Vector{Reference}
     N_data::Int
-    T_range::Tuple{T,T}
-    p_range::Tuple{T,T}
+    T_range::Tuple{Float64,Float64}
+    p_range::Tuple{Float64,Float64}
 end
 
 function BaseParam(prop::P, Mw, dat::D; solute=nothing) where
@@ -39,10 +39,9 @@ function BaseParam(prop::P, Mw, dat::D; solute=nothing) where
     if prop isa InfDiffusionCoefficient
         Mw = [calc_M_CE([Mw[1],get_Mw(solute)[1]])]
     end
-    TT = Base.promote_eltype(dat.T,dat.p)
 
-    T_range = TT.(extrema(dat.T))
-    p_range = TT.(extrema(dat.p))
+    T_range = extrema(dat.T)
+    p_range = extrema(dat.p)
     return BaseParam(prop, solute_name, Mw, [Reference()], dat.N_dat, T_range, p_range)
 end
 
@@ -55,30 +54,14 @@ function BaseParam(prop::P, Mw, ref=[Reference()], N_dat=0, T_range=(NaN,NaN),
     return BaseParam(prop, solute_name, Mw, ref, N_dat, T_range, p_range)
 end
 
-function BaseParam{P,TT}(prop::P, Mw, ref=[Reference()], N_dat=0, T_range=(NaN,NaN),
+function BaseParam{P}(prop::P, Mw, ref=[Reference()], N_dat=0, T_range=(NaN,NaN),
     p_range=(NaN,NaN); solute_name=missing) where
-    {TT,P <: AbstractTransportProperty}
+    {P <: AbstractTransportProperty}
     if prop isa InfDiffusionCoefficient
         Mw = [calc_M_CE(Mw) for _ in 1:length(Mw)]
     end
-    return BaseParam(prop, solute_name, Mw, ref, N_dat, TT.(T_range), TT.(p_range))
+    return BaseParam(prop, solute_name, Mw, ref, N_dat, T_range, p_range)
 end
-
-function Base.convert(::Type{BaseParam{P,T1}},param::BaseParam{P,T2}) where {P,T1,T2}
-    prop = param.prop
-    solute_name = param.solute_name
-    Mw = param.Mw
-    param_ref = param.param_ref
-    N_data = param.N_data
-    T_range = T1.(param.T_range)
-    p_range = T1.(param.p_range)
-    return BaseParam(prop,solute_name,Mw,param_ref,N_data,T_range,p_range)
-end
-
-# function BaseParam(prop::P, )
-
-#     return BaseParam(prop, Mw, [Reference("fit")], dat.N_dat, T_range, p_range)
-# end
 
 struct Viscosity <: AbstractViscosity end
 name(::AbstractViscosity) = "viscosity"

--- a/src/models/framework.jl
+++ b/src/models/framework.jl
@@ -190,23 +190,10 @@ get_prop_type(::FrameworkParams{T,P}) where {T, P <: AbstractTransportProperty} 
 get_prop_type(::Type{FrameworkParams{T,P}}) where {T, P <: AbstractTransportProperty} = P 
 function Base.getindex(model::FrameworkModel, prop::P) where P <: AbstractTransportProperty
     return getindex_prop(model.params,prop)
-    #=
-    tprop = typeof(prop)
-    k = get_prop_type.(model.params) .== tprop
-    if sum(k) == 1
-        i = findfirst(k)
-    elseif sum(k) == 0
-        @info "No parameters for $tprop."
-        i = k
-    else
-        @info "Multiple parameters for $tprop. Returning the first one."
-        i = findfirst(k)
-    end
-    return model.params[i] =#
 end
 
 @generated function getindex_prop(x::T,prop::P) where {T<:NTuple{<:Any,FrameworkParams},P<:AbstractTransportProperty}
-    idx = findfirst(xi ->get_prop_type(xi) == P,fieldtypes(T))
+    idx = findfirst(Base.Fix1(transport_compare_type,P),fieldtypes(T))
     if isnothing(idx)
         return quote
             throw(error("cannot found specified property $P"))
@@ -218,7 +205,7 @@ end
 end
 
 function getindex_prop(x,prop::P) where P <: AbstractTransportProperty
-    idx = findfirst(xi ->get_prop_type(xi) == P,x)
+    idx = findfirst(Base.Fix1(transport_compare_type,P),x)
     if isnothing(idx)
         return quote
             throw(error("cannot found specified property $P"))

--- a/src/models/framework.jl
+++ b/src/models/framework.jl
@@ -6,33 +6,42 @@ export FrameworkModel, FrameworkParams
 Structure to store the parameters of the framework model. The parameters are:
 """
 struct FrameworkParams{T,P} <: AbstractEntropyScalingParams
-    α::Array{T,2}
+    α::Matrix{T}
     m::Vector{Float64}
     σ::Vector{Float64}
     ε::Vector{Float64}
     Y₀⁺min::Vector{Float64}
-    base::BaseParam{P}
-end 
+    base::BaseParam{P,T}
+end
 
 # Constructor for fitting
 function FrameworkParams(prop::AbstractTransportProperty, eos, data; solute=nothing)
     α0 = get_α0_framework(prop)
     σ, ε, Y₀⁺min = init_framework_model(eos, prop; solute=solute)
     base = BaseParam(prop, get_Mw(eos), data; solute=solute)
-    return FrameworkParams(α0, get_m(eos), σ, ε, Y₀⁺min, base)
+    TT = Base.promote_eltype(α0,base.p_range)
+    if TT != typeof(base.p_range[1])
+        _base = convert(BaseParam{typeof(prop),TT},base)
+    else
+        _base = base
+    end
+    _α0 = convert(Vector{TT},α0)
+    return FrameworkParams(_α0, get_m(eos), σ, ε, Y₀⁺min, _base)
 end
 
 # Constructor for existing parameters
-function FrameworkParams(prop::AbstractTransportProperty, eos, α::Array{T,2}; 
+function FrameworkParams(prop::AbstractTransportProperty, eos, α::Array{T,2};
                          solute=nothing) where {T}
-    size(α,1) == 5 || error("Parameter array 'α' must have 5 rows.")
-    size(α,2) == length(eos) || error("Parameter array 'α' doesn't fit EOS model.")
+    size(α,1) == 5 || throw(DimensionMismatch("Parameter array 'α' must have 5 rows."))
+    size(α,2) == length(eos) || throw(DimensionMismatch("Parameter array 'α' doesn't fit EOS model."))
 
     σ, ε, Y₀⁺min = init_framework_model(eos, prop; solute=solute)
     return FrameworkParams(α, get_m(eos), σ, ε, Y₀⁺min, BaseParam(prop, get_Mw(eos)))
 end
 
-get_α0_framework(prop) = any(typeof(prop) .<: [Viscosity, DiffusionCoefficient]) ? zeros(Real,5,1) : [1.;zeros(Real,4,1);]
+#get_α0_framework(prop) = any(typeof(prop) .<: [Viscosity, DiffusionCoefficient]) ? zeros(Real,5,1) : [1.;zeros(Real,4,1);]
+get_α0_framework(prop::Union{Viscosity,DiffusionCoefficient}) = zeros(5,1)
+get_α0_framework(prop) = zeros(4,1)
 
 function init_framework_model(eos, prop; solute=nothing)
     # Calculation of σ and ε
@@ -65,33 +74,66 @@ end
 
 A generic entropy scaling model.
 """
-struct FrameworkModel{T} <: AbstractEntropyScalingModel
+struct FrameworkModel{E,FP} <: AbstractEntropyScalingModel
     components::Vector{String}
-    params::Vector{FrameworkParams}
-    eos::T
+    params::FP
+    eos::E
 end
 
-FrameworkModel(eos,params) = FrameworkModel(get_components(eos),params,eos)
+FrameworkModel(eos,params::Tuple) = FrameworkModel(get_components(eos),params,_framework_cache(eos))
+FrameworkModel(eos,params::AbstractVector) = FrameworkModel(eos,tuple(params...))
+_framework_cache(eos) = eos
 
-function cite_model(::FrameworkModel) 
+function cite_model(::FrameworkModel)
     print("Entropy Scaling Framework:\n---\n" *
-          "(1) Schmitt, S.; Hasse, H.; Stephan, S. Entropy Scaling Framework for " * 
+          "(1) Schmitt, S.; Hasse, H.; Stephan, S. Entropy Scaling Framework for " *
           "Transport Properties Using Molecular-Based Equations of State. Journal of " *
           "Molecular Liquids 2024, 395, 123811. DOI: " *
           "https://doi.org/10.1016/j.molliq.2023.123811")
     return nothing
 end
 
-function FrameworkModel(eos, param_dict::Dict{P,Array{T,2}}) where 
+function FrameworkModel(eos, param_dict::Dict{P,Array{T,2}}) where
                         {T,P <: AbstractTransportProperty}
-    params = FrameworkParams[]
+    params_vec = FrameworkParams[]
     for (prop, α) in param_dict
-        push!(params, FrameworkParams(prop, eos, α))
+        push!(params_vec, FrameworkParams(prop, eos, α))
     end
+    params = tuple(params_vec...)
     return FrameworkModel(eos, params)
 end
 
-function FrameworkModel(eos, datasets::Vector{TPD}; opts::FitOptions=FitOptions(), 
+#show methods for FrameworkModel
+function Base.show(io::IO,::MIME"text/plain",model::FrameworkModel)
+    n = length(model.components)
+    print(io,"FrameworkModel")
+    print(io," with ",n," component")
+    n != 1 && print(io,"s")
+    println(io,":")
+    Base.print_matrix(IOContext(io, :compact => true),model.components)
+    println(io)
+    print(io," Available properties: ")
+    np = length(model.params)
+    for i in 1:length(model.params)
+        param_i = model.params[i]
+        print(io,name(param_i.base.prop))
+        i != np && print(io,", ")
+    end
+    println(io)
+    print(io," Equation of state: ")
+    print(io,model.eos)
+end
+
+function Base.show(io::IO,model::FrameworkModel)
+    print(io,"FrameworkModel(")
+    print(io,typeof(model.eos))
+    print(io,", ")
+    types = map(x -> x.base.prop,model.params)
+    print(io,types)
+end
+
+
+function FrameworkModel(eos, datasets::Vector{TPD}; opts::FitOptions=FitOptions(),
                         solute=nothing) where TPD <: TransportPropertyData
     # Check eos and solute
     length(eos) == 1 || error("Only one component allowed for fitting.")
@@ -100,7 +142,7 @@ function FrameworkModel(eos, datasets::Vector{TPD}; opts::FitOptions=FitOptions(
     for prop in [Viscosity(), ThermalConductivity(), SelfDiffusionCoefficient(), InfDiffusionCoefficient()]
         data = collect_data(datasets, prop)
         if data.N_dat > 0
-            if typeof(prop) == InfDiffusionCoefficient 
+            if typeof(prop) == InfDiffusionCoefficient
                 isnothing(solute) && error("Solute EOS model must be provided for diffusion coefficient at infinite dilution.")
                 solute_ = solute
             else
@@ -112,7 +154,7 @@ function FrameworkModel(eos, datasets::Vector{TPD}; opts::FitOptions=FitOptions(
             param = FrameworkParams(prop, eos, data; solute=solute_)
 
             #TODO make this a generic function
-            # Calculate density 
+            # Calculate density
             for k in findall(isnan.(data.ϱ))
                 data.ϱ[k] = molar_density(eos, data.p[k], data.T[k])
             end
@@ -137,7 +179,7 @@ function FrameworkModel(eos, datasets::Vector{TPD}; opts::FitOptions=FitOptions(
             sol = solve(prob, SimpleGaussNewton(), reltol=1e-8)
             α_fit = get_α0_framework(prop)
             α_fit[what_fit] .= sol.u
-            
+
             push!(params, FrameworkParams(float.(α_fit), param.m, param.σ, param.ε, param.Y₀⁺min, param.base))
         end
     end
@@ -145,8 +187,10 @@ function FrameworkModel(eos, datasets::Vector{TPD}; opts::FitOptions=FitOptions(
 end
 
 get_prop_type(::FrameworkParams{T,P}) where {T, P <: AbstractTransportProperty} = P
-
+get_prop_type(::Type{FrameworkParams{T,P}}) where {T, P <: AbstractTransportProperty} = P 
 function Base.getindex(model::FrameworkModel, prop::P) where P <: AbstractTransportProperty
+    return getindex_prop(model.params,prop)
+    #=
     tprop = typeof(prop)
     k = get_prop_type.(model.params) .== tprop
     if sum(k) == 1
@@ -158,27 +202,59 @@ function Base.getindex(model::FrameworkModel, prop::P) where P <: AbstractTransp
         @info "Multiple parameters for $tprop. Returning the first one."
         i = findfirst(k)
     end
-    return model.params[i]
+    return model.params[i] =#
 end
 
+@generated function getindex_prop(x::T,prop::P) where {T<:NTuple{<:Any,FrameworkParams},P<:AbstractTransportProperty}
+    idx = findfirst(xi ->get_prop_type(xi) == P,fieldtypes(T))
+    if isnothing(idx)
+        return quote
+            throw(error("cannot found specified property $P"))
+        end
+    else
+        f = fieldtypes(T)[idx]
+        return :(x[$idx]::$(f))
+    end
+end
+
+function getindex_prop(x,prop::P) where P <: AbstractTransportProperty
+    idx = findfirst(xi ->get_prop_type(xi) == P,x)
+    if isnothing(idx)
+        return quote
+            throw(error("cannot found specified property $P"))
+        end
+    else
+        return x[idx]
+    end
+end
 
 # Scaling model (correlation: Yˢ = Yˢ(sˢ,α,g))
 function scaling_model(param::FrameworkParams{T,Viscosity}, s, x=[1.]) where T
-    g = [-1.6386, 1.3923]
+    g = (-1.6386, 1.3923)
     return generic_scaling_model(param, s, x, g)
 end
 function scaling_model(param::FrameworkParams{T,ThermalConductivity}, s, x=[1.]) where T
-    g = [-1.9107, 1.0725]
+    g = (-1.9107, 1.0725)
     return generic_scaling_model(param, s, x, g)
 end
 function scaling_model(param::FrameworkParams{T,P}, s, x=[1.]) where {T, P<:DiffusionCoefficient}
-    g = [ 0.6632, 9.4714]
+    g =  (0.6632, 9.4714)
     return generic_scaling_model(param, s, x, g)
 end
 
 function generic_scaling_model(param::FrameworkParams, s, x, g)
-    α = param.α * x
-    return (α' * [1., log(s+1.), s, s^2, s^3]) / (1. + g' * [log(s+1.), s])
+    α = param.α
+    g1,g2 = g[1],g[2]
+    num = zero(Base.promote_eltype(α,s,x,g))
+    num += _dot(@view(α[1,:]),x) + _dot(@view(α[2,:]),x)*log1p(s)
+    denom = 1 + g1*log1p(s) + g2*s
+    si = s
+    for i in 3:length(α)
+        num += _dot(@view(α[i,:]),x)*si
+        si *= s
+    end
+    return num/denom
+    #return (α' * [1., log(s+1.), s, s^2, s^3]) / (1. + g1 * [log(s+1.), s])
 end
 
 function scaling(param::FrameworkParams, eos, Y, T, ϱ, s, z=[1.]; inv=false)
@@ -188,31 +264,42 @@ function scaling(param::FrameworkParams, eos, Y, T, ϱ, s, z=[1.]; inv=false)
     sˢ = reduced_entropy(param,s,z)
 
     # Transport property scaling
+    if length(z) == 1
+        _1 = one(eltype(z))
+        Y₀⁺_all = _1*property_CE_plus(param.base.prop, eos, T, param.σ[1], param.ε[1])
+        Y₀⁺min = _1*param.Y₀⁺min[1]
+    else
+        Y₀⁺_all = property_CE_plus.(param.base.prop, split_model(eos), T, param.σ, param.ε)
+        Y₀⁺ = mix_CE(param.base, Y₀⁺_all, z)
+        Y₀⁺min = mix_CE(param.base, param.Y₀⁺min, z)
+    
+    end
     Y₀⁺_all = property_CE_plus.(param.base.prop, split_model(eos), T, param.σ, param.ε)
     Y₀⁺ = mix_CE(param.base, Y₀⁺_all, z)
     Y₀⁺min = mix_CE(param.base, param.Y₀⁺min, z)
-    
+
     W(x, sₓ=0.5, κ=20.0) = 1.0/(1.0+exp(κ*(x-sₓ)))
     Yˢ = (W(sˢ)/Y₀⁺ + (1.0-W(sˢ))/Y₀⁺min)^k * plus_scaling(param.base, Y, T, ϱ, s, z; inv=inv)
-
     return Yˢ
 end
 
 function reduced_entropy(param::FrameworkParams, s, z=[1.])
-    return -s / R / sum(param.m .* z)
+    return -s / R / _dot(param.m,z)
 end
 
 function viscosity(model::FrameworkModel, p, T, z=[1.]; phase=:unknown)
     ϱ = molar_density(model.eos, p, T, z; phase=phase)
     return ϱT_viscosity(model, ϱ, T, z)
 end
+
 function ϱT_viscosity(model::FrameworkModel, ϱ, T, z=[1.])
+    #param = model[Viscosity()]
     param = model[Viscosity()]
     s = entropy_conf(model.eos, ϱ, T, z)
     sˢ = reduced_entropy(param, s, z)
     ηˢ = exp(scaling_model(param, sˢ, z))
 
-    return scaling(param, model.eos, ηˢ, T, ϱ, s, z; inv=true) 
+    return scaling(param, model.eos, ηˢ, T, ϱ, s, z; inv=true)
 end
 
 function thermal_conductivity(model::FrameworkModel, p, T, z=[1.]; phase=:unknown)
@@ -225,7 +312,7 @@ function ϱT_thermal_conductivity(model::FrameworkModel, ϱ, T, z=[1.])
     sˢ = reduced_entropy(param, s, z)
     λˢ = scaling_model(param, sˢ, z)
 
-    return scaling(param, model.eos, λˢ, T, ϱ, s, z; inv=true) 
+    return scaling(param, model.eos, λˢ, T, ϱ, s, z; inv=true)
 end
 
 function self_diffusion_coefficient(model::FrameworkModel, p, T, z=[1.]; phase=:unknown)
@@ -243,7 +330,7 @@ function ϱT_self_diffusion_coefficient(model::FrameworkModel, ϱ, T)
     sˢ = reduced_entropy(param, s)
     Dˢ = exp(scaling_model(param, sˢ))
 
-    return scaling(param, model.eos, Dˢ, T, ϱ, s; inv=true) 
+    return scaling(param, model.eos, Dˢ, T, ϱ, s; inv=true)
 end
 
 function ϱT_self_diffusion_coefficient(model::FrameworkModel, ϱ, T, z)
@@ -256,7 +343,7 @@ function ϱT_self_diffusion_coefficient(model::FrameworkModel, ϱ, T, z)
     for i in 1:length(model.eos)
         αi[:,i] = param_self.α[:,i]
         αi[:,3-i] = param_inf.α[:,3-i]
-        
+
         param = FrameworkParams(SelfDiffusionCoefficient(), model.eos, αi)
         sˢ = reduced_entropy(param, s, z)
         Dˢ = exp(scaling_model(param, sˢ, z))
@@ -276,5 +363,5 @@ function ϱT_MS_diffusion_coefficient(model::FrameworkModel, ϱ, T, z)
     sˢ = reduced_entropy(param, s, z)
     Dˢ = exp(scaling_model(param, sˢ, z))
 
-    return scaling(param, model.eos, Dˢ, T, ϱ, s, z; inv=true) 
+    return scaling(param, model.eos, Dˢ, T, ϱ, s, z; inv=true)
 end

--- a/src/utils/data.jl
+++ b/src/utils/data.jl
@@ -12,12 +12,12 @@ struct TransportPropertyData{P} <: AbstractTransportPropertyData
     phase::Vector{Symbol}
     ref::Vector{Reference}
 end
-function Base.show(io::IO, data::TransportPropertyData) 
+function Base.show(io::IO, data::TransportPropertyData)
     print(io,"$(typeof(data))\n    $(data.N_dat) data points.")
     return nothing
 end
 
-function TransportPropertyData(prop, T::Vector, p, ϱ, Y::Vector, phase::Symbol, 
+function TransportPropertyData(prop, T::Vector, p, ϱ, Y::Vector, phase::Symbol,
                                doi::String="", short::String="")
     N_dat = length(T)
     if isempty(p) && !isempty(ϱ)
@@ -29,7 +29,7 @@ function TransportPropertyData(prop, T::Vector, p, ϱ, Y::Vector, phase::Symbol,
     end
     [length(k) != N_dat && error("All vectors must have the same length.") for k in [p,ϱ,Y]]
 
-    return TransportPropertyData(prop, length(T), T, p, ϱ, Y, repeat([phase],N_dat), 
+    return TransportPropertyData(prop, length(T), T, p, ϱ, Y, repeat([phase],N_dat),
                                  repeat([Reference(doi,short)],N_dat))
 end
 ViscosityData(args...) = TransportPropertyData(Viscosity(), args...)
@@ -37,7 +37,7 @@ ThermalConductivityData(args...) = TransportPropertyData(ThermalConductivity(), 
 SelfDiffusionCoefficientData(args...) = TransportPropertyData(SelfDiffusionCoefficient(), args...)
 InfDiffusionCoefficientData(args...) = TransportPropertyData(InfDiffusionCoefficient(), args...)
 
-function collect_data(  datasets::Vector{TPD}, prop::AbstractTransportProperty) where 
+function collect_data(  datasets::Vector{TPD}, prop::AbstractTransportProperty) where
                         TPD <: TransportPropertyData
     (T, p, ϱ, Y, phase, ref) = (Float64[], Float64[], Float64[], Float64[], Symbol[], Reference[])
     N_dat = 0
@@ -53,7 +53,7 @@ function collect_data(  datasets::Vector{TPD}, prop::AbstractTransportProperty) 
     return TransportPropertyData(prop, N_dat, T, p, ϱ, Y, phase, ref)
 end
 
-function filter_datasets(datasets::Vector{TPD}, prop) where TPD <: TransportPropertyData 
+function filter_datasets(datasets::Vector{TPD}, prop) where TPD <: TransportPropertyData
     return filter(data -> data.prop == prop, datasets)
 end
 

--- a/test/chapman_enskog.jl
+++ b/test/chapman_enskog.jl
@@ -1,0 +1,6 @@
+@testset "Chapman-Enskog" begin
+    @testset "LJ Collision Int" begin
+        @test EntropyScaling.Ω_22(0.9) ≈ 1.68262401248626
+        @test EntropyScaling.Ω_11(0.9) ≈ 1.517529517136435
+    end
+end

--- a/test/framework.jl
+++ b/test/framework.jl
@@ -93,4 +93,9 @@
             @test MS_diffusion_coefficient(model_3, 0.1e6, 308.15, [.5,.5]) ≈ 3.333533e-9 rtol=1e-5
         end
     end
+
+    @testset "misc" begin
+        @test EntropyScaling.Ω_22(0.9) ≈ 1.68262401248626
+        @test EntropyScaling.Ω_11(0.9) ≈ 1.517529517136435
+    end
 end

--- a/test/framework.jl
+++ b/test/framework.jl
@@ -93,9 +93,4 @@
             @test MS_diffusion_coefficient(model_3, 0.1e6, 308.15, [.5,.5]) ≈ 3.333533e-9 rtol=1e-5
         end
     end
-
-    @testset "misc" begin
-        @test EntropyScaling.Ω_22(0.9) ≈ 1.68262401248626
-        @test EntropyScaling.Ω_11(0.9) ≈ 1.517529517136435
-    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,3 +4,4 @@ using Clapeyron
 using DelimitedFiles
 
 include("framework.jl")
+include("chapman_enskog.jl")


### PR DESCRIPTION
This PR adds the following:
- a lot of speed ups (manual addition instead of allocating vectors, less type instability)
- some caching on the Clapeyron part (`split_model` is slow, but we have a `EoSVectorParam` that stores the result of `split_model`)
- `Base.show` methods for `FrameworkModel`:
  ```julia
  julia> model
  FrameworkModel with 1 component:
   "n-butane"
   Available properties: viscosity, self-diffusion coefficient, thermal conductivity
   Equation of state: Clapeyron.EoSVectorParam{PCSAFT{BasicIdeal, Float64}}("n-butane")
  ```
- new abstract types: `AbstractViscosity` and `AbstractThermalConductivity`, this allows `model[Viscosity()]` to get any viscosity method, not just the exact match for `Viscosity()`, with this change, new methods for viscosity can be defined. (main motivation of this PR, i want to add a REFPROP RES viscosity method soon)