### PR TITLE
Doc maintain

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -12,17 +12,17 @@ Then, the module can be loaded by
 using EntropyScaling
 ```
 
-## EOS Calculations
+## EoS Calculations
 
 The calculation of transport properties through entropy scaling is mostly based on 
-fundamental EOS (defined in the Helmholtz energy $a$) as they allow the consistent calculation
+fundamental EoS (defined in the Helmholtz energy $a$) as they allow the consistent calculation
 of all required thermodynamic properties, in particular the configurational entropy $s_{\rm conf}$. 
-The EOS calculations are not part of this package.
+The EoS calculations are *not* part of this package.
 However, there is an extension to the [`Clapeyron.jl`](https://github.com/ClapeyronThermo/Clapeyron.jl) package,
 which provides a large number of different thermodynamic models.
 The extension is automatically loaded when loading both packages `EntropyScaling.jl` and `Clapeyron.jl`.
 Alternatively, custom thermodynamic models can be used by 'dispatching' the functions defined 
-in the [`thermo.jl`](https://github.com/se-schmitt/EntropyScaling.jl/blob/main/src/utils/thermo.jl) file to a custom EOS type.
+in the [`thermo.jl`](https://github.com/se-schmitt/EntropyScaling.jl/blob/main/src/utils/thermo.jl) file to a custom EoS type.
 
 ```julia
 using EntropyScaling, Clapeyron

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,14 +1,14 @@
 # EntropyScaling.jl
 
-Transport property modeling based on entropy scaling and equations of state (EOS).
+Transport property modeling based on entropy scaling and equations of state (EoS).
 
 This package provides methods to model 
-- the viscosity,
+- the dynamic viscosity,
 - the thermal conductivity, and
 - diffusion coefficients
 
-in a physically sound way. For the EOS calculations, additional packages need to be imported.
-Alternatively, custom EOS functions can be defined. Implementations of EOS models are *not*
+in a physically sound way. For the EoS calculations, additional packages need to be imported.
+Alternatively, custom EoS functions can be defined. Implementations of EoS models are *not*
 included in this package.
 
 Entropy scaling makes use of the fact that transport properties can be scaled such that the

--- a/docs/src/models/ES_models.md
+++ b/docs/src/models/ES_models.md
@@ -15,9 +15,9 @@ The following entropy scaling models are currently implemented:
 
 All models are similarly structured with the following fields:
 
-- `components::Vector{String}`: names of the chemical components of the system
-- `params::Vector{ModelParams}`: vector of model-specific paramater objects
-- `eos`: EOS model
+- `components::Vector{String}`: names of the chemical components of the system,
+- `params::Vector{ModelParams}`: vector of model-specific paramater objects,
+- `eos`: EoS model.
 
 The `ModelParams` are model-specific types containing all required parameters of the model.
 They always contain the Chapman-Enskog model (`CE_model`) as well as base parameters (`base`)

--- a/src/general/chapman_enskog.jl
+++ b/src/general/chapman_enskog.jl
@@ -206,7 +206,7 @@ struct Neufeld <: AbstractCollisionIntegralMethod end
 Ω(prop::DiffusionCoefficient,method::Neufeld,T_red) = Ω_11_neufeld(T_red)
 
 """
-    Ω(poperty::AbstractTransportProperty, model::AbstractChapmanEnskogModel, T)
+    Ω(property::AbstractTransportProperty, model::AbstractChapmanEnskogModel, T)
 
 Calculates the collision integral for a given `model` and `property` (`Ω₁₁` for diffusion coefficients and `Ω₂₂` for viscosity/thermal conductivity) at the specified temperature `T`.
 

--- a/src/general/properties.jl
+++ b/src/general/properties.jl
@@ -1,7 +1,7 @@
 """
     viscosity(model::EntropyScalingModel, p, T, z=[1.]; phase=:unknown)
 
-Viscosity `η(p,T,x)` (`[η] = Pa s`).
+Dynamic viscosity `η(p,T,x)` (`[η] = Pa s`).
 """
 viscosity
 

--- a/src/models/framework.jl
+++ b/src/models/framework.jl
@@ -21,7 +21,7 @@ end
 function FrameworkParams(prop::AbstractTransportProperty, eos, α::Array{T,2};
                          solute=nothing) where {T}
     size(α,1) == 5 || throw(DimensionMismatch("Parameter array 'α' must have 5 rows."))
-    size(α,2) == length(eos) || throw(DimensionMismatch("Parameter array 'α' doesn't fit EOS model."))
+    size(α,2) == length(eos) || throw(DimensionMismatch("Parameter array 'α' doesn't fit EoS model."))
 
     Mw = get_Mw(eos)
     CE_model, Y₀⁺min = init_framework_params(eos, prop; Mw=Mw, solute=solute)    
@@ -85,16 +85,15 @@ end
 Entropy scaling framework [schmitt_entropy_2024,schmitt_entropy_2025](@cite).
 
 The entropy scaling framework provides a physical way to model transport properties 
-(viscosity, thermal conductivity, diffusion coeffficients) based on molecular-based EOS.
+(dynamic viscosity, thermal conductivity, diffusion coeffficients) based on molecular-based EoS.
 It enables fitting new models using only few experimental data.
 
 # Parameters
 
-- `α::Matrix{T}`: component-specific parameters (size: `5 x N_components`)
-
-`m` (segment parameter of molecular-based EOS) and `Y₀⁺min` (minimum of the scaled 
-zero-density transport property) are additional internal parameters (not to be set at 
-construction).
+- `α::Matrix{T}`: component-specific parameters (size: `5 x N_components`),
+- `m` (segment parameter of molecular-based EoS)  
+- `Y₀⁺min` (minimum of the scaled zero-density transport property) are additional internal parameters 
+(not to be set at construction).
 
 # Constructors
 
@@ -103,7 +102,7 @@ construction).
     Constructor for fitting new parameters `α` to experimental data (only applicable to pure components).
     `datasets` contains the experimental data, see [`TransportPropertyData`](@ref).
     `opts` enables controling the fitting procedure through [`FitOptions`](@ref).
-    `solute` is an EOS model of the solute (optional, for fitting diff. coeff. at infinite dilution).
+    `solute` is an EoS model of the solute (optional, for fitting diff. coeff. at infinite dilution).
     
 # Example 
 
@@ -114,13 +113,13 @@ using EntropyScaling, Clapeyron
 (T_exp,ϱ_exp,η_exp) = EntropyScaling.load_sample_data()
 data = ViscosityData(T_exp, [], ϱ_exp, η_exp, :unknown)
 
-# Create EOS model
+# Create EoS model
 eos_model = PCSAFT("butane")
 
 # Create entropy scaling model (fit of parameters)
 model = FrameworkModel(eos_model, [data])
 
-# Calculation of the viscostiy at state
+# Calculation of the dynamic viscosity at state (p = 1E5 Pa, T = 300 K)
 η = viscosity(model, 0.1e6, 300.)
 ```
 """
@@ -153,7 +152,7 @@ function FrameworkModel(eos, datasets::Vector{TPD}; opts::FitOptions=FitOptions(
         data = collect_data(datasets, prop)
         if data.N_dat > 0
             if typeof(prop) == InfDiffusionCoefficient
-                isnothing(solute) && error("Solute EOS model must be provided for diffusion coefficient at infinite dilution.")
+                isnothing(solute) && error("Solute EoS model must be provided for diffusion coefficient at infinite dilution.")
                 solute_ = solute
             else
                 solute_ = nothing

--- a/src/models/refprop_res.jl
+++ b/src/models/refprop_res.jl
@@ -21,7 +21,7 @@ end
 """
     RefpropRESModel{T} <: AbstractEntropyScalingModel
 
-Entropy scaling model based on Refprop EOS [yang_linking_2022,yang_entropy_2021](@cite). 
+Entropy scaling model based on Refprop EoS [yang_linking_2022,yang_entropy_2021](@cite). 
 
 A database provides ready-to-use models for the viscosity of several fluids.
 The model can favourably be used in combination with [`Clapeyron.jl`](https://github.com/ClapeyronThermo/Clapeyron.jl) and [`Coolprop.jl`](https://github.com/CoolProp/CoolProp.jl) (see examples).
@@ -38,10 +38,10 @@ The model can favourably be used in combination with [`Clapeyron.jl`](https://gi
 
 - `RefpropRESModel(eos, params::Dict{P})`: Default constructor (see above).
 - `RefpropRESModel(eos, components)`: Creates a ES model using the parameters provided in the database (recommended). 
-    `RefpropRESModel(components)` creates the EOS model on-the-fly (only works if `Clapeyron.jl` and `Coolprop.jl` are loaded).
+    `RefpropRESModel(components)` creates the EoS model on-the-fly (only works if `Clapeyron.jl` and `Coolprop.jl` are loaded).
 
 !!! info
-    The default CoolProp EOS is used here which does not necessarily match the choice of the original papers. 
+    The default CoolProp EoS is used here which does not necessarily match the choice of the original papers. 
     This might lead to slight deviations to the values in the original papers (especially for the thermal conductivity).
 
 # Example
@@ -156,7 +156,7 @@ function thermal_conductivity_critical(crit_param, eos, ϱ, T, η, z)
     # Parameters 
     φ0, Γ, qD, Tref = [_dot(crit_param[k],z) for k in (:φ0, :Γ, :qD, :Tref)]
     
-    # EOS
+    # EoS
     ∂ϱ∂p = ForwardDiff.derivative(xp -> molar_density(eos, xp, T, z; ϱ0=ϱ), pressure(eos, ϱ, T, z))
     ∂ϱ∂p_Tref = ForwardDiff.derivative(xp -> molar_density(eos, xp, Tref, z; ϱ0=ϱ), pressure(eos, ϱ, Tref, z))
     Δ∂ϱ∂p = ∂ϱ∂p - Tref/T*∂ϱ∂p_Tref

--- a/src/utils/misc.jl
+++ b/src/utils/misc.jl
@@ -7,13 +7,13 @@ const SAMPLE_PATH = normpath(Base.pkgdir(EntropyScaling),"test","data")
 function load_sample_data(;prop="eta")
     if prop == "eta"
         @info "Experimental data for the viscosity of n-butane.\n" *
-              "\tUnits: [T] = K, [ϱ] = mol/m³, [η] = Pa·s"
+              "\tUnits: [T] = K, [ϱ] = mol m⁻³, [η] = Pa·s"
     elseif prop == "lambda"
         @info "Experimental data for the thermal conductivity of n-butane.\n" *
-              "\tUnits: [T] = K, [ϱ] = mol/m³, [λ] = W/m·K"
+              "\tUnits: [T] = K, [ϱ] = mol m⁻³, [λ] = W (m·K)⁻¹"
     elseif prop == "D"
         @info "Experimental data for the self-diffusion coefficient of n-butane.\n" *
-              "\tUnits: [T] = K, [ϱ] = mol/m³, [D] = m²/s"
+              "\tUnits: [T] = K, [ϱ] = mol m⁻³, [D] = m² s⁻¹"
     else
         error("Invalid keyword value: prop = $prop")
     end

--- a/src/utils/thermo.jl
+++ b/src/utils/thermo.jl
@@ -12,42 +12,42 @@ pressure(eos::Any, ϱ, T, z=Z1) = fun_na_error("pressure",typeof(eos))
 """
     molar_density(eos, p, T, z=[1.]; phase=:unknown)
 
-Molar density `ϱ` (`[ϱ] = mol/m³`).
+Molar density `ϱ` (`[ϱ] = mol m⁻³`).
 """
 molar_density(eos::Any, p, T, z=Z1; phase=:unknown, ϱ0=nothing) = fun_na_error("molar_density",typeof(eos))
 
 """
     entropy_conf(eos, ϱ, T, z=[1.])
 
-Configurational (or residual) entropy `s_conf` (`[s_conf] = J/(mol K)`).
+Configurational (or residual) entropy `s_conf` (`[s_conf] = J (mol K)⁻¹`).
 """
 entropy_conf(eos::Any, ϱ, T, z=Z1) = fun_na_error("entropy_conf",typeof(eos))
 
 """
     second_virial_coefficient(eos, T, z=[1.])
 
-Second virial coefficient `B` (`[B] = m³/mol`).
+Second virial coefficient `B` (`[B] = m³ mol⁻¹`).
 """
 second_virial_coefficient(eos::Any, T, z=Z1) = fun_na_error("second_virial_coefficient",typeof(eos))
 
 """
     second_virial_coefficient_dT(eos, T, z=[1.])
 
-Temperature derivative of the second virial coefficient `dBdT` (`[dBdT] = m³/(mol K)`).
+Temperature derivative of the second virial coefficient `dBdT` (`[dBdT] = m³ (mol K)⁻¹`).
 """
 second_virial_coefficient_dT(eos::Any, T, z=Z1) = ForwardDiff.derivative(xT -> second_virial_coefficient(eos, xT, z), T)
 
 """
     isobaric_heat_capacity(eos, ϱ, T, z=[1.])
 
-Isobaric heat capacity `cₚ` (`[cₚ] = J/(mol K)`).
+Isobaric heat capacity `cₚ` (`[cₚ] = J (mol K)⁻¹`).
 """
 isobaric_heat_capacity(eos::Any, ϱ, T, z=Z1) = fun_na_error("isobaric_heat_capacity",typeof(eos))
 
 """
     isochoric_heat_capacity(eos, ϱ, T, z=[1.])
 
-Isochoric heat capacity `cₚ` (`[cₚ] = J/(mol K)`).
+Isochoric heat capacity `cₚ` (`[cₚ] = J (mol K)⁻¹`).
 """
 isochoric_heat_capacity(eos::Any, ϱ, T, z=Z1) = fun_na_error("isochoric_heat_capacity",typeof(eos))
 
@@ -55,14 +55,14 @@ isochoric_heat_capacity(eos::Any, ϱ, T, z=Z1) = fun_na_error("isochoric_heat_ca
 """
     crit_pure(eos)
 
-Critical point of pure component (`Tc`, `pc`, `ϱc`) (`[Tc] = K`, `[pc] = Pa`, `[ϱc] = mol/m³`).
+Critical point of pure component (`Tc`, `pc`, `ϱc`) (`[Tc] = K`, `[pc] = Pa`, `[ϱc] = mol m⁻³`).
 """
 crit_pure(eos::Any) = fun_na_error("crit_pure",typeof(eos))
 
 """
     crit_mix(eos, x)
 
-Critical point of a mixture at given composition (`Tc`, `pc`, `ϱc`) (`[Tc] = K`, `[pc] = Pa`, `[ϱc] = mol/m³`).
+Critical point of a mixture at given composition (`Tc`, `pc`, `ϱc`) (`[Tc] = K`, `[pc] = Pa`, `[ϱc] = mol m⁻³`).
 """
 crit_mix(eos::Any, z) = fun_na_error("crit_mix",typeof(eos))
 
@@ -77,14 +77,14 @@ split_model(eos::Any) = fun_na_error("split_model",typeof(eos))
 """
     get_Mw(eos)
 
-Molar mass(es) of the syste (`[Mw] = kg/mol`).
+Molar mass(es) of the system (`[Mw] = kg mol⁻¹`).
 """
 get_Mw(eos::Any) = fun_na_error("get_Mw",typeof(eos))
 
 """
     get_m(eos)
 
-Segment parameter of SAFT-type EOS.
+Segment parameter of SAFT-type EoS.
 """
 get_m(eos::Any) = fun_na_error("get_m",typeof(eos))
 


### PR DESCRIPTION
Updates functions documentation, update unit display. Refactor `viscosity` to `dynamic viscosity` because ultimately giving user the possibility to make kinematic viscosity calculation is pretty cool and having molar density and molar mass already calculated should easy the implementation. Final goal of this is to implement Prandlt's number calculation because for transport phenomena study this is a cool metric to use correlations.